### PR TITLE
fix: ordering to User model

### DIFF
--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -44,3 +44,6 @@ class User(AbstractUser, PermissionsMixin):
     uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
 
     USERNAME_FIELD = "username"
+
+    class Meta:
+        ordering = ["username"]


### PR DESCRIPTION
In order to remove `UnorderedObjectListWarning` from the test result.

It was the following:
```
============================================================================================== warnings summary ===============================================================================================
apps/users/tests/test_users_views.py::test_user_get_view[authenticated_client-200]
  /usr/local/lib/python3.12/site-packages/rest_framework/pagination.py:207: UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list: <class 'apps.users.models.User'> QuerySet.
    paginator = self.django_paginator_class(queryset, page_size)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================= 30 passed, 1 warning in 20.64s ========================================================================================
```